### PR TITLE
Move database connections to "conftest" file and delete unnecessary functions

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -1,4 +1,5 @@
 from datetime import datetime
+import psycopg2
 import pytest
 from selenium import webdriver
 
@@ -15,3 +16,11 @@ def browser():
     driver.implicitly_wait(5)
     yield driver
     driver.quit()
+
+
+@pytest.fixture(scope='session')
+def postgres_connections():
+    db = psycopg2.connect(dbname='postgres', user='postgres',
+                          password='postgres', host='localhost')
+    yield db
+    db.close()

--- a/pages/change_user_page.py
+++ b/pages/change_user_page.py
@@ -1,6 +1,5 @@
 from pages.base_page import BasePage
 from pages.change_user_page_locators import ChangeUserPageLocators
-from tools.db_steps import db_get_test_user_id
 
 """Страница изменения данных пользователя"""
 

--- a/test_gjango_app.py
+++ b/test_gjango_app.py
@@ -3,11 +3,12 @@ from pages.admin_page import AdminPage
 from pages.login_page import LoginPage
 from tools import db_steps
 from constants import NEW_USER_USERNAME
+from tools.db_steps import DataBase
 
 """Страница с тестами"""
 
 
-def test_add_new_user(browser):
+def test_add_new_user(browser, postgres_connections):
     """
     1.	Открыть приложение
     2.	Войти в админку
@@ -27,7 +28,9 @@ def test_add_new_user(browser):
     log_out_page = admin_page.log_out()
 
     """4.	Проверить что пользователь создан в дб"""
-    assert 'test_user' in db_steps.db_users()
+    postgres = DataBase(postgres_connections)
+    assert 'test_user' in postgres.db_users()
+
 
 def test_open_app_by_new_user(browser):
     """
@@ -41,6 +44,3 @@ def test_open_app_by_new_user(browser):
     welcome_user_element = admin_page.find_welcome_user_element()
 
     assert welcome_user_element.text == NEW_USER_USERNAME.upper()
-
-
-

--- a/tools/db_steps.py
+++ b/tools/db_steps.py
@@ -1,35 +1,17 @@
-import psycopg2
-
 """Степы для запросов из базы данных"""
 
 
-def db_users():
-    '''
-    Функция подключается к базе данных и возвращает список созданных пользователей
-    '''
-    db = psycopg2.connect(dbname='postgres', user='postgres',
-                          password='postgres', host='localhost')
-    users = []
-    cursor = db.cursor()
-    cursor.execute("""SELECT username FROM auth_user""")
-    for name in cursor.fetchall():
-        users.append(''.join(name))
-    return users
+class DataBase:
+    def __init__(self, db_connections):
+        self.db_connections = db_connections
 
-
-def db_get_test_user_id():
-
-    db = psycopg2.connect(dbname='postgres', user='postgres',
-                          password='postgres', host='localhost')
-    cursor = db.cursor()
-    cursor.execute(
-        """SELECT id FROM auth_user""")
-    for i in cursor.fetchall():
-        if i != '1':
-            id = str(i)
-    return id
-
-
-if __name__ == '__main__':
-    print(db_users())
-    print(db_get_test_user_id())
+    def db_users(self):
+        '''
+        Функция подключается к базе данных и возвращает список созданных пользователей
+        '''
+        cursor = self.db_connections.cursor()
+        cursor.execute("""SELECT username FROM auth_user""")
+        users = []
+        for name in cursor.fetchall():
+            users.append(''.join(name))
+        return users


### PR DESCRIPTION
Были исправлены следующие комментарии:
1) def db_users():
    '''
    Функция подключается к базе данных и возвращает список созданных пользователей
    '''
    db = psycopg2.connect(dbname='postgres', user='postgres',
                          password='postgres', host='localhost')
    users = []
    cursor = db.cursor()
    cursor.execute("""SELECT username FROM auth_user""")
    for name in cursor.fetchall():
        users.append(''.join(name))
    return users

в степах в бд в каждом степе есть описание 
db = psycopg2.connect(dbname='postgres', user='postgres',
                          password='postgres', host='localhost')

само подключение лучше вынести в конфтест в фикстуру, и уже это подключение принимать на вход степов к бд

2) if name == '__main__':
    print(db_users())
    print(db_get_test_user_id())

нужно только для дебага

3) def db_get_test_user_id():

    db = psycopg2.connect(dbname='postgres', user='postgres',
                          password='postgres', host='localhost')
    cursor = db.cursor()
    cursor.execute(
        """SELECT id FROM auth_user""")
    for i in cursor.fetchall():
        if i != '1':
            id = str(i)
    return id

нужно переделать запрос чтобы он вынимал или все, или нужный айди по имени юзера
 if i != '1'